### PR TITLE
spicetify-themes: Change to v2 branch

### DIFF
--- a/bucket/spicetify-themes.json
+++ b/bucket/spicetify-themes.json
@@ -1,19 +1,15 @@
 {
-    "version": "2021-05-21T05.54.11",
+    "version": "1.1.61.583.gad060c66",
     "description": "Community-created themes for Spicetify.",
     "homepage": "https://github.com/morpheusthewhite/spicetify-themes",
     "license": "MIT",
     "depends": "spicetify-cli",
-    "url": "https://github.com/morpheusthewhite/spicetify-themes/archive/master.zip",
-    "hash": "9e7bd01c5cb14b0e29e052472342e7cae84de51898489a23f3ca4d36dc8b58f5",
+    "url": "https://github.com/morpheusthewhite/spicetify-themes/archive/refs/heads/v2.zip",
+    "hash": "4e5bd57ad9a17d63ec3f4d01f63a8f17a0322bb48652cca3a77ed0911269e69f",
     "notes": [
-        "The Elementary theme requires the Open Sans and Raleway fonts:",
-        "scoop bucket add nerd-fonts",
-        "sudo scoop install open-sans raleway",
-        "The WintergatanBlueprint theme requires the Ubuntu font:",
-        "scoop bucket add nerd-fonts",
-        "sudo scoop install Ubuntu-NF",
-        "A preview of all of the themes can be found here: https://github.com/morpheusthewhite/spicetify-themes/wiki/Themes-preview"
+        "Only a few themes are available for v2 currently",
+        "Dribbblish requires more installation steps, check its README for details",
+        "A preview of all of the themes can be found here: https://github.com/morpheusthewhite/spicetify-themes/blob/v2/THEMES.md"
     ],
     "extract_dir": "spicetify-themes-master",
     "installer": {
@@ -33,8 +29,6 @@
             "    Copy-Item -Recurse $_.FullName -Destination \"$env:USERPROFILE\\.spicetify\\Themes\"",
             "}",
             "",
-            "(Get-Content \"$env:USERPROFILE\\.spicetify\\Themes\\Elementary\\user.css\").Replace('Google Sans', 'Open Sans') | Set-Content \"$env:USERPROFILE\\.spicetify\\Themes\\Elementary\\user.css\"",
-            "",
             "init-spicetify-config-and-apply"
         ]
     },
@@ -42,11 +36,11 @@
         "script": "Get-ChildItem \"$dir\" | ForEach-Object { Remove-Item -Recurse -ErrorAction Ignore \"$env:USERPROFILE\\.spicetify\\Themes\\$($_.Name)\" }"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/morpheusthewhite/spicetify-themes/commits",
+        "url": "https://api.github.com/repos/morpheusthewhite/spicetify-themes/commits/v2",
         "regex": "([\\d-]+T)(\\d+):(\\d+):(\\d+)",
         "replace": "$1$2.$3.$4"
     },
     "autoupdate": {
-        "url": "https://github.com/morpheusthewhite/spicetify-themes/archive/master.zip"
+        "url": "https://github.com/morpheusthewhite/spicetify-themes/archive/refs/heads/v2.zip"
     }
 }


### PR DESCRIPTION
spicetify-cli v2 requires new themes, stored on the v2 branch of spicetify-themes, for now. This switches to this branch and "updates" to the newest commit.

This fixes #52, and I recommend that #51 is merged for similar reasons.