### PR TITLE
Update the config init script to handle both the profiles

### DIFF
--- a/scripts/init-spicetify-config.ps1
+++ b/scripts/init-spicetify-config.ps1
@@ -10,10 +10,11 @@ if (-not (Test-Path "$env:APPDATA\Spotify\prefs")) {
 Stop-Process -ErrorAction Ignore -Name Spotify
 
 $config_exists = Test-Path "$env:USERPROFILE\.spicetify\config.ini"
+$new_config_exists = Test-Path "$env:USERPROFILE\.spicetify\config-xpui.ini"
 
 & "$PSScriptRoot\spicetify.exe" config spotify_path "$(Resolve-Path(Split-Path $spotify_path))" --quiet
 
-if (-not $config_exists) {
+if (-not ($config_exists -or $new_config_exists)) {
     & "$PSScriptRoot\spicetify.exe" config experimental_features 1 --quiet
     & "$PSScriptRoot\spicetify.exe" config fastUser_switching 1 --quiet
     & "$PSScriptRoot\spicetify.exe" config extensions "autoSkipExplicit.js|bookmark.js|fullAppDisplay.js|keyboardShortcut.js|newRelease.js|queueAll.js|shuffle+.js|trashbin.js|webnowplaying.js" --quiet


### PR DESCRIPTION
Now that we have 2 versions of the config script, for backwards compatibility sake, we should check for both and only add the extensions and stuff when we need to, otherwise we can end up with something like this

```
extensions     = default-dynamic.js|Vibrant.min.js|bookmark.js|fullAppDisplay.js|keyboardShortcut.js|shuffle+.js|trashbin.js|webnowplaying.js|autoSkipExplicit.js|bookmark.js|fullAppDisplay.js|keyboardShortcut.js|newRelease.js|queueAll.js|shuffle+.js|trashbin.js|webnowplaying.js
```