### PR TITLE
remove old deprecated extensions from script

### DIFF
--- a/scripts/init-spicetify-config.ps1
+++ b/scripts/init-spicetify-config.ps1
@@ -16,5 +16,5 @@ $config_exists = Test-Path "$env:USERPROFILE\.spicetify\config.ini"
 if (-not $config_exists) {
     & "$PSScriptRoot\spicetify.exe" config experimental_features 1 --quiet
     & "$PSScriptRoot\spicetify.exe" config fastUser_switching 1 --quiet
-    & "$PSScriptRoot\spicetify.exe" config extensions "autoSkipExplicit.js|bookmark.js|fullAppDisplay.js|keyboardShortcut.js|newRelease.js|queueAll.js|shuffle+.js|trashbin.js|webnowplaying.js" --quiet
+    & "$PSScriptRoot\spicetify.exe" config extensions "autoSkipExplicit.js|bookmark.js|fullAppDisplay.js|keyboardShortcut.js|shuffle+.js|trashbin.js|webnowplaying.js" --quiet
 }


### PR DESCRIPTION
These two no longer exist in the repo and are giving errors every time `spicetify apply` is run.

```powershell
spicetify-apply.cmd
spicetify v2.7.1
....
....
Transferring extensions:
error Extension "newRelease.js" not found.
error Extension "queueAll.js" not found.
OK
Transferring custom apps:
OK
success Spotify is spiced up!
```