### PR TITLE
Fixed BlockTheSpot install

### DIFF
--- a/bucket/blockthespot.json
+++ b/bucket/blockthespot.json
@@ -13,7 +13,7 @@
             "    exit 1",
             "}",
             "",
-            "$null, $bucket = find_manifest($app)",
+            "$null, $null, $bucket, $null = Get-Manifest($app)",
             "$bucketdir = Find-BucketDirectory($bucket)",
             "Copy-Item \"$bucketdir\\..\\scripts\\blockthespot.ps1\" -Destination $dir",
             "& \"$dir\\blockthespot.ps1\""

--- a/scripts/blockthespot.ps1
+++ b/scripts/blockthespot.ps1
@@ -17,12 +17,11 @@ if ((Split-Path $spotify_dir_parent -leaf) -ne "spotify-latest") {
     }
 }
 
-if ((Get-FileHash "$spotify_dir\chrome_elf.dll").Hash -ne (Get-FileHash "$PSScriptRoot\chrome_elf.dll").Hash) {
+if ((Get-FileHash -ErrorAction SilentlyContinue "$spotify_dir\dpapi.dll").Hash -ne (Get-FileHash "$PSScriptRoot\dpapi.dll").Hash) {
     $spotify_running = Get-Process -ErrorAction Ignore -Name Spotify
     Stop-Process -ErrorAction Ignore -Name Spotify | Out-Null
 
-    Move-Item -Force "$spotify_dir\chrome_elf.dll" -Destination "$spotify_dir\chrome_elf.dll.original"
-    Copy-Item "$PSScriptRoot\chrome_elf.dll" -Destination "$spotify_dir"
+    Copy-Item "$PSScriptRoot\dpapi.dll" -Destination "$spotify_dir"
 
     if (-not (Get-Content -ErrorAction Ignore "$spotify_dir\config.ini")) { Copy-Item "$PSScriptRoot\config.ini" -Destination "$spotify_dir" }
 


### PR DESCRIPTION
The installation for BlockTheSpot `scoop install blockthespot` was throwing a few errors:

> find_manifest : The term 'find_manifest' is not recognized as the name of a cmdlet, function, script file, or operable
> program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
> At line:6 char:18
> \+ $null, $bucket = find_manifest($app)
> \+                  ~~~~~~~~~~~~~
>     \+ CategoryInfo          : ObjectNotFound: (find_manifest:String) [], CommandNotFoundException
>     \+ FullyQualifiedErrorId : CommandNotFoundException

This was solved by updating the usage of `find_manifest` to `Get-Manifest`.

Once that was done, I discovered that **blockthespot.ps1** was outdated as well, in that it tried to replace **_chrome_elf.dll_** with a modified version that does not exist anymore in the **chrome_elf.zip** released by BlockTheSpot, which now makes use of the injection of a different dll, namely **_dpapi.dll_**.

This simple pull request should fix both.